### PR TITLE
test: Add test fixtures and unit tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,6 @@ jobs:
       - name: Install pretix
         run: pip install pretix
       - name: Install plugin and test deps
-        run: pip install pytest pytest-django -Ue .
+        run: pip install pytest pytest-django pytest-cov -Ue .
       - name: Run tests
-        run: pytest tests
+        run: pytest --cov=pretix_signature_capture tests

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help localecompile localegen requirements lint
+.PHONY: help localecompile localegen requirements lint test fix
 
 # Put it first so that "make" without argument is like "make help".
 PYTHON_VERSION := $(shell python3 -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["requires-python"])')
@@ -12,7 +12,7 @@ help:
 
 # Tool lists, kept here so they live in one place and don't drift.
 LINT_TOOLS  := isort flake8 black docformatter
-TEST_TOOLS  := pytest pytest-django
+TEST_TOOLS  := pytest pytest-django pytest-cov
 BUILD_TOOLS := build twine check-manifest
 
 
@@ -28,6 +28,9 @@ lint:  ## Run all linters in check mode (no auto-fix). Mirrors what CI runs.
 	flake8 .
 	black --check .
 	docformatter --check -r .
+
+test:  ## Run pytest with coverage. Mirrors what CI runs.
+	pytest --cov=pretix_signature_capture tests
 
 fix:  ## Runs isort, black, and docformatter to autofix linting issues
 	isort . && black . && docformatter -r .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,3 +58,11 @@ exclude = [
 # versions get consistent output.
 [tool.black]
 target-version = ["py311", "py312", "py313"]
+
+[tool.pytest.ini_options]
+DJANGO_SETTINGS_MODULE = "pretix.testutils.settings"
+# Ignore warnings coming from site packages
+filterwarnings = [
+    "ignore:::pretix",
+    "ignore:::django"
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,9 +38,6 @@ force_grid_wrap = 0
 line_length = 88
 known_first_party = pretix_signature_capture
 
-[tool:pytest]
-DJANGO_SETTINGS_MODULE = pretix.testutils.settings
-
 [coverage:run]
 source = pretix_signature_capture
 omit = */migrations/*,*/urls.py,*/tests/*

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,18 +12,10 @@ Reference: ``pretix/src/tests/conftest.py``.
 
 import datetime
 import inspect
-
 import pytest
 from django.utils.timezone import now
 from django_scopes import scope, scopes_disabled
-
-from pretix.base.models import (
-    CartPosition,
-    Event,
-    Item,
-    Organizer,
-    Question,
-)
+from pretix.base.models import CartPosition, Event, Item, Organizer, Question
 
 
 @pytest.hookimpl(hookwrapper=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,96 @@
-# put your pytest fixtures here
+"""Pytest fixtures for pretix-signature-capture tests.
+
+Pretix's own test conftest (under ``pretix/src/tests/``) provides a
+``pytest_fixture_setup`` hook that auto-disables django-scopes for any
+non-generator fixture. Out-of-tree plugin tests don't run under that
+parent conftest, so we replicate the hook here. Without it, every fixture
+that touches a scoped model (Event, Item, Question, CartPosition, ...)
+would need its own ``with scopes_disabled():`` block.
+
+Reference: ``pretix/src/tests/conftest.py``.
+"""
+
+import datetime
+import inspect
+
+import pytest
+from django.utils.timezone import now
+from django_scopes import scope, scopes_disabled
+
+from pretix.base.models import (
+    CartPosition,
+    Event,
+    Item,
+    Organizer,
+    Question,
+)
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_fixture_setup(fixturedef, request):
+    """Disable django-scopes for non-generator fixtures (mirrors pretix)."""
+    if inspect.isgeneratorfunction(fixturedef.func):
+        yield
+    else:
+        with scopes_disabled():
+            yield
+
+
+@pytest.fixture
+def organizer():
+    """A bare Organizer with slug ``dummy``."""
+    org = Organizer.objects.create(name="Dummy", slug="dummy")
+    with scope(organizer=org):
+        yield org
+
+
+@pytest.fixture
+def event(organizer):
+    """An Event under ``organizer`` with this plugin enabled."""
+    return Event.objects.create(
+        organizer=organizer,
+        name="Dummy Event",
+        slug="dummy",
+        date_from=now(),
+        live=True,
+        plugins="pretix_signature_capture",
+    )
+
+
+@pytest.fixture
+def item(event):
+    """A simple paid Item attached to ``event``."""
+    return Item.objects.create(event=event, name="Ticket", default_price=23)
+
+
+@pytest.fixture
+def file_question(event, item):
+    """A file-upload Question attached to ``item``.
+
+    This is the question type the plugin extends — see issue #5+ for the
+    label-text-marker -> proper-API migration.
+    """
+    q = Question.objects.create(
+        event=event,
+        question="Signature",
+        type=Question.TYPE_FILE,
+        required=False,
+    )
+    item.questions.add(q)
+    return q
+
+
+@pytest.fixture
+def cart_position(event, item, file_question):
+    """A CartPosition for ``item`` in a fresh cart, with ``file_question`` attached.
+
+    Returns the CartPosition; the related question is reachable via
+    ``cart_position.item.questions.first()``.
+    """
+    return CartPosition.objects.create(
+        event=event,
+        cart_id="dummy_cart",
+        item=item,
+        price=23,
+        expires=now() + datetime.timedelta(minutes=10),
+    )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,42 @@
-def test_empty():
-    # put your first tests here
-    assert 1 + 1 == 2
+"""Smoke tests for the plugin scaffolding.
+
+The goal of this module is to prove that the test environment (pretix
+test settings, DB, plugin loader, template/static finders) is wired up
+correctly. Per-feature tests live in their own modules.
+"""
+
+import pytest
+from django_scopes import scopes_disabled
+
+from pretix_signature_capture.signals import html_head_presale
+
+
+@pytest.mark.django_db
+def test_html_head_presale_renders_plugin_script_tags(event):
+    """The html_head receiver should return rendered HTML referencing
+    the plugin's bundled JS via ``{% static %}``."""
+    rendered = html_head_presale(sender=event, request=None)
+
+    assert isinstance(rendered, str)
+    assert "<script" in rendered
+    # Templates use {% static "pretix_signature_capture/<file>" %} so the
+    # rendered URL contains this path segment regardless of STATIC_URL.
+    assert "pretix_signature_capture/jSignature.min.js" in rendered
+    assert "pretix_signature_capture/main.js" in rendered
+
+
+@pytest.mark.django_db
+@scopes_disabled()
+def test_cart_position_fixture_is_wired_up(cart_position, file_question):
+    """Sanity check that the conftest fixtures compose correctly:
+    a cart position whose item has a file-type question attached.
+
+    The conftest ``pytest_fixture_setup`` hook disables django-scopes for
+    fixture *creation* but not for the test body, so any in-body queries
+    on scoped models (Item, Question, ...) need an explicit
+    ``@scopes_disabled()`` decorator. Mirrors how pretix's own tests
+    handle this — e.g. ``tests/plugins/sendmail/test_rules.py``.
+    """
+    assert cart_position.pk is not None
+    assert cart_position.item.questions.filter(pk=file_question.pk).exists()
+    assert file_question.type == "F"


### PR DESCRIPTION
* `tests/conftest.py` now provides the organizer, event, item, file_question, and `cart_position` fixtures that #4 calls for. The `cart_position` composes through item -> file_question, so the file-type Question is attached to the position's item out of the box. I also ported pretix's own `pytest_fixture_setup` hook so non-generator fixtures don't each need a `scopes_disabled()` block — without that, every fixture touching a scoped model would explode under django-scopes.

* `tests/test_main.py` replaces the 1+1 placeholder with two tests:

  * The required one calls `html_head_presale(sender=event, request=None)` directly and asserts the rendered output is a string containing `<script` plus the static paths `pretix_signature_capture/jSignature.min.js` and `pretix_signature_capture/main.js`.

  * The second is a small smoke test that exercises the `cart_position` fixture so the scaffolding can't silently rot.

* Makefile got a new `test` target (`pytest --cov=pretix_signature_capture tests`)
 
* `.github/workflows/tests.yml` now installs pytest-cov and runs the same coverage-enabled invocation, so make test and CI stay in lockstep.